### PR TITLE
Remove ribbon from catalog service

### DIFF
--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -31,7 +31,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring-cloud.bom.version>Greenwich.SR3</spring-cloud.bom.version>
+        <spring-cloud.bom.version>Hoxton.SR9</spring-cloud.bom.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <spring-boot-maven-plugin.version>2.2.10.RELEASE</spring-boot-maven-plugin.version>
     </properties>

--- a/catalog/src/main/resources/static/index.html
+++ b/catalog/src/main/resources/static/index.html
@@ -48,7 +48,7 @@
     <hr>
 
     <footer>
-        <p>&copy; Red Hat 2017</p>
+        <p>&copy; Red Hat 2021</p>
     </footer>
 </div> <!-- /container -->
 


### PR DESCRIPTION
Remove ribbon in favor of direct communication to inventory service.

Coincides with RedHat-Middleware-Workshops/cloud-native-workshop-v2m1-guides#37