### PR TITLE
Update endpoints to https

### DIFF
--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -11,12 +11,12 @@ components:
       endpoints:
         - exposure: public
           name: index-webpage
-          protocol: http
+          protocol: https
           targetPort: 8080
         - exposure: public
           name: quarkus-devui
           path: /q/dev
-          protocol: http
+          protocol: https
           targetPort: 8080
         - exposure: none
           name: quarkus-debug


### PR DESCRIPTION
Recent versions of chrome and firefox switch to https automatically